### PR TITLE
Account of out of range tiles in ITile Get/Set

### DIFF
--- a/FakeProvider/TileProvider/TileProviderCollection.cs
+++ b/FakeProvider/TileProvider/TileProviderCollection.cs
@@ -87,6 +87,9 @@ namespace FakeProvider
         {
             get
             {
+                if (X < 0 || Y < 0 || X >= Width || Y >= Height)
+                    return VoidTile;
+
                 lock (Locker)
                 {
                     return _GlobalProvidersBuffer[ProviderIndexes[X, Y]].GetTileInWorld(X, Y);
@@ -94,6 +97,9 @@ namespace FakeProvider
             }
             set
             {
+                if (X < 0 || Y < 0 || X >= Width || Y >= Height)
+                    return;
+
                 lock (Locker)
                 {
                     _GlobalProvidersBuffer[ProviderIndexes[X, Y]].SetTileInWorld(X, Y, value);


### PR DESCRIPTION
this adds boundary checks to the tile indexer to prevent the special world generation seeds from triggering an infinite recursion crash at the edges of the map; with some seeds like planetoids this can lead to this behaviour.